### PR TITLE
fix id counter in phpipam_api_client class

### DIFF
--- a/php-client/class.phpipam-api.php
+++ b/php-client/class.phpipam-api.php
@@ -547,7 +547,7 @@ class phpipam_api_client  {
                 $this->api_server_identifiers = array();
                 foreach ($identifiers as $cnt=>$i) {
                     if($cnt==0) { $this->api_server_identifiers['id']   = $i; }
-                    else        { $this->api_server_identifiers['id'.$i] = $i; }
+                    else        { $this->api_server_identifiers['id'.($cnt+1)] = $i; }
                 }
 
             }


### PR DESCRIPTION
This fixes the case where if there is more than one parameter, the identifier keys were munged instead of sequencing as id2, id3 etc.
