### PR TITLE
fix error where api identifiers were lingering between calls

### DIFF
--- a/php-client/class.phpipam-api.php
+++ b/php-client/class.phpipam-api.php
@@ -538,6 +538,7 @@ class phpipam_api_client  {
      * @return void
      */
     public function set_api_identifiers ($identifiers) {
+        $this->api_server_identifiers = false;         // clear this to forget any previous settings 
         if(is_array($identifiers)) {
             if(sizeof($identifiers)>0 && !$this->api_encrypt) {
                 // reset


### PR DESCRIPTION
This fixes a problem where a second call to execute() was inheriting in the identifier array ids from an earlier request, which broke it.  (Specifically, doing a POST to create a specific IP address where a previous call had converted the subnet CIDR to a subnetId.)