### PR TITLE
added phpipam-pyclient submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "powershell-client"]
 	path = powershell-client
 	url = https://github.com/yoke88/PSPHPIPAM.git
+[submodule "phpipam-pyclient"]
+	path = phpipam-pyclient
+	url = https://github.com/viniciusarcanjo/phpipam-pyclient.git


### PR DESCRIPTION
Hi @phpipam, 

I've added this [phpipam-pyclient](https://github.com/viniciusarcanjo/phpipam-pyclient.git) submodule, it's a rest-client compatible with both Python2.7 and 3.5. It's been fully tested and with docs on ReadTheDocs, could you merge this PR?

Thanks!