### PR TITLE
Add phpipamsdk to the libraries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "phpipam-pyclient"]
 	path = phpipam-pyclient
 	url = https://github.com/viniciusarcanjo/phpipam-pyclient.git
+[submodule "phpipamsdk"]
+	path = phpipamsdk
+	url = https://github.com/efenian/phpipamsdk.git


### PR DESCRIPTION
Just would like to add https://github.com/efenian/phpipamsdk.git to the list.

I'm currently working with some integrations of phpipam, zabbix and netdisco. Tested a lot of libraries arround GitHub this days, and find out that python one to be the most complete and helpfull at the moment.